### PR TITLE
Linux build

### DIFF
--- a/Makefile_gbdk
+++ b/Makefile_gbdk
@@ -1,0 +1,24 @@
+PROJ=gbdk_player
+GBDK=../gbdk/
+OBJ=build
+SRC=player-gbdk
+TGT=rom
+
+DRV=hUGEDriver
+MOD=song
+CVTFLAGS=-b0
+
+all:
+	mkdir -p $(OBJ)
+	mkdir -p $(TGT)
+
+	rgbasm -DGBDK -o$(OBJ)/$(DRV).obj hUGEDriver.asm
+	tools/rgb2sdas $(CVTFLAGS) $(OBJ)/$(DRV).obj
+	$(GBDK)bin/sdar -ru $(OBJ)/hUGEDriver.lib $(OBJ)/$(DRV).obj.o
+	$(GBDK)bin/lcc -I$(SRC) -Wl-m -Wl-w -Wl-j -Wm-yS -Wl-k$(OBJ) -Wl-lhUGEDriver.lib -o $(TGT)/$(PROJ).gb $(SRC)/$(PROJ).c song/C/$(MOD).c
+
+clean:
+	rm -f $(TGT)/$(PROJ).gb
+	rm -f $(TGT)/$(PROJ).map
+	rm -f $(TGT)/$(PROJ).ihx
+	rm -f $(TGT)/$(PROJ).noi

--- a/player-gbdk/gbdk_player.c
+++ b/player-gbdk/gbdk_player.c
@@ -22,10 +22,10 @@ void main() {
 
     __critical {
         hUGE_init(&Intro);
-        add_VBL(hUGE_dosound);
     }
         
     while(1) {
+        hUGE_dosound();
         wait_vbl_done();
         joy = joypad();
         switch (joy) {

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ This refactored driver has several advantages:
 5. _make_gbdk.bat compiles a player using GBDK-2020, _make_rgbds.bat compiles a player using RGBDS; rom-files will be located in the \rom folder; you must have more GBDK-2020 v4.0, in case you want to compile gbdk_player.gb, because bat-scripts are written for it.
 6. objects that might be linked with your homebrew software are located in the \build folder: hUGEDriver.obj song.obj in RGBDS format, hUGEDriver.obj.o in SDAS format for use with GBDK.
 
+
 # Notes
 
 1. C header file for the driver is here: \player-gbdk\hUGEDriver.h, example of usage is gbdk_player.c
@@ -39,3 +40,26 @@ rgb2sdas is a utility that converts RGBDS object files to SDAS object files. unf
 
 	example 2; converting the song object, place it into bank 1, rename symbol to Intro:
 		rgb2sdas -c_CODE_1 -r_song_descriptor=_Intro song.obj
+
+
+# Build from linux
+
+## Build rgb2sdas
+
+Prerequisite: 
+
+```
+sudo apt install fpc
+```
+
+```
+cd tools/src
+make 
+```
+
+## Build player GBDK 
+
+```
+cd ../..
+make -f Makefile_gbdk
+```

--- a/tools/src/Makefile
+++ b/tools/src/Makefile
@@ -1,0 +1,5 @@
+all:
+	fpc -B -Xs -FE.. -FU. rgb2sdas.pas
+
+clean:
+	rm -f *.o

--- a/tools/src/rgb2sdas.pas
+++ b/tools/src/rgb2sdas.pas
@@ -163,9 +163,9 @@ begin
   with TObjFileStream.Create(afilename, fmOpenRead) do try 
     Read(Result, SizeOf(TRObj) - SizeOf(Result.Symbols) - SizeOf(Result.Sections) - SizeOf(Result.Nodes));
 
-    if (not CompareMem(@Result.ID, @Sign, sizeof(Result.ID))) or (not InRange(Result.RevisionNumber, 6, 8)) then
+    if (not CompareMem(@Result.ID, @Sign, sizeof(Result.ID))) or (not InRange(Result.RevisionNumber, 6, 9)) then
       Die(
-        'Unsupported object file version! This version of rgb2sdas supports RGB9, revision 6, 7, or 8 files. The provided file is '+
+        'Unsupported object file version! This version of rgb2sdas supports RGB9, revision 6, 7, 8 or 9 files. The provided file is '+
         Result.ID+', revision '+IntToStr(Result.RevisionNumber)+'.'
       );
 
@@ -590,7 +590,7 @@ begin
     Writeln(F, 'XL3');
     Writeln(F, Format('H %x areas %x global symbols', [RObj.NumberOfSections, idx]));
     Writeln(F, Format('M %s', [StringReplace(ExtractFileName(sourcename), '.', '_', [rfReplaceAll])]));
-    Writeln(F, 'O -mgbz80');
+    Writeln(F, 'O -msm83');
 
     // output all imported symbols
     for I:= Low(RObj.Symbols) to High(RObj.Symbols) do


### PR DESCRIPTION
In this PR, some modification has been made to build under Linux (ubuntu 22.10)

# Makefiles 

Build ok, updated doc

# gbdk_player.c 

`add_VBL(hUGE_dosound);` raise the following error: 

```
../gbdk/bin/lcc -Iplayer-gbdk -Wl-m -Wl-w -Wl-j -Wm-yS -Wl-kbuild -Wl-lhUGEDriver.lib -o rom/gbdk_player.gb player-gbdk/gbdk_player.c song/C/song.c
player-gbdk/gbdk_player.c:
player-gbdk/gbdk_player.c:25: error 78: incompatible types
from type 'void function ( ) __sdcccall(0) fixed'
  to type 'void function ( ) code* fixed'
``` 

Instead of using VBL, just call `hUGE_dosound()` in the main loop, before `wait_vbl_done`

**There is probably a proper way to fix this issue, you might want to ignore this change**


# rgb2sdas

* Continue to build when object file is RGB9 R9 

* output object header from -msm83 to -mgbz80 

to fix the following error when build: 

```
rgb2sdas converting build/hUGEDriver.obj --> build/hUGEDriver.obj.o result: success!
../gbdk/bin/sdar -ru build/hUGEDriver.lib build/hUGEDriver.obj.o
../gbdk/bin/lcc -Iplayer-gbdk -Wl-m -Wl-w -Wl-j -Wm-yS -Wl-kbuild -Wl-lhUGEDriver.lib -o rom/gbdk_player.gb player-gbdk/gbdk_player.c song/C/song.c
player-gbdk/gbdk_player.c:
song/C/song.c:
?ASlink-Warning-Conflicting sdcc options:
   "-msm83" in module "gbdk_player" and
   "-mgbz80" in module "hUGEDriver_obj".
make: *** [Makefile_gbdk:17 : all] Erreur 1
```

**I have no idea what this option do, this modification works for me but you might also want to not merge this change**
